### PR TITLE
Add id to testcase name for secrets to prevent deduplication

### DIFF
--- a/secscanner2junit/vulnerability.py
+++ b/secscanner2junit/vulnerability.py
@@ -55,6 +55,7 @@ class _Vulnerability(_Base):
         self.__solution = super()._parse_simple_property('solution')
         self.__identifiers = super()._parse_required_property_list('identifiers', Identifier)
         self.__links = super()._parse_simple_property_list('links', Link)
+        self._location = None  # Disable name mangling for subclass.
         # details
         # tracking
         # flags
@@ -78,7 +79,8 @@ class _Vulnerability(_Base):
             return self.__identifiers[0].get_name() + id_part + severity_part
 
     def get_location(self):
-        pass
+        if self._location is not None:
+            return self._location.get_location()
 
     def get_description(self):
         if len(self.__description) > 0:
@@ -105,19 +107,16 @@ class _Vulnerability(_Base):
 class SastVulnerability(_Vulnerability):
     def __init__(self, raw_vulnerability: dict):
         super().__init__(raw_vulnerability)
-        self.__location = SastLocation(super()._parse_required_property('location'))
+        self._location = SastLocation(super()._parse_required_property('location'))
 
-    def get_location(self):
-        return self.__location.get_location()
+    def get_start_line(self):
+        return self._location.get_start_line()
 
 
 class ContainerScanningVulnerability(_Vulnerability):
     def __init__(self, raw_vulnerability: dict):
         super().__init__(raw_vulnerability)
-        self.__location = ContainerScanningLocation(super()._parse_required_property('location'))
-
-    def get_location(self):
-        return self.__location.get_location()
+        self._location = ContainerScanningLocation(super()._parse_required_property('location'))
 
 
 class Identifier(_Base):
@@ -160,6 +159,9 @@ class SastLocation(Location):
 
     def get_location(self):
         return self.__file
+
+    def get_start_line(self):
+        return self.__start_line
 
 
 # https://gitlab.com/gitlab-org/security-products/security-report-schemas/-/blob/master/src/container-scanning-report-format.json

--- a/tests/resources/test_secrets/test_secret_suppression/gl-secret-detection.json
+++ b/tests/resources/test_secrets/test_secret_suppression/gl-secret-detection.json
@@ -1,0 +1,170 @@
+{
+  "version": "14.0.4",
+  "vulnerabilities": [
+    {
+      "id": "ca2e630da4ff16c5956022e72b787c2ac42f56d0f8e0986f450066d05724876c",
+      "category": "secret_detection",
+      "name": "Twitch API token",
+      "message": "Twitch API token detected; please remove and revoke it if this is a leak.",
+      "description": "Twitch API token",
+      "cve": "secrets.go:b8be0ec61f03232c3e42bc4367cb4e29cdedf97bcec9f389e5c9add98d03db2a:twitch-api-token",
+      "severity": "Critical",
+      "confidence": "Unknown",
+      "raw_source_code_extract": "zwqjvffo863374zioz1gd26thgsmu5",
+      "scanner": {
+        "id": "gitleaks",
+        "name": "Gitleaks"
+      },
+      "location": {
+        "file": "secrets.go",
+        "commit": {
+          "sha": "0000000"
+        },
+        "start_line": 112,
+        "end_line": 112
+      },
+      "identifiers": [
+        {
+          "type": "gitleaks_rule_id",
+          "name": "Gitleaks rule ID twitch-api-token",
+          "value": "twitch-api-token"
+        }
+      ]
+    },
+    {
+      "id": "3e7ceb66a6fc7dffd614e57c5b6ffcee051ffa189ba60d30b6458d654aa37711",
+      "category": "secret_detection",
+      "name": "Typeform API token",
+      "message": "Typeform API token detected; please remove and revoke it if this is a leak.",
+      "description": "Typeform API token",
+      "cve": "secrets.go:e0d09b6c64bd911106de66ebbdef7b61fffaddf89a4192169018d1a3cce08299:typeform-api-token",
+      "severity": "Critical",
+      "confidence": "Unknown",
+      "raw_source_code_extract": "tfp_HeDK4ZeCwwCHdvSnVnzKtjiyB1rLFyzspa7Y3Fo9yAp8_3pcodefNH4DhnE",
+      "scanner": {
+        "id": "gitleaks",
+        "name": "Gitleaks"
+      },
+      "location": {
+        "file": "secrets.go",
+        "commit": {
+          "sha": "0000000"
+        },
+        "start_line": 114,
+        "end_line": 114
+      },
+      "identifiers": [
+        {
+          "type": "gitleaks_rule_id",
+          "name": "Gitleaks rule ID typeform-api-token",
+          "value": "typeform-api-token"
+        }
+      ]
+    },
+    {
+      "id": "c0e2a4d68eba7e91cc408c74f1603b32ccbac63a800734b106abbdb8d8a6352c",
+      "category": "secret_detection",
+      "name": "Generic API Key",
+      "message": "Generic API Key detected; please remove and revoke it if this is a leak.",
+      "description": "Generic API Key",
+      "cve": "secrets.go:2d6e84fe17bb198a507e017fd57740761f2ff960528ad4e1540ec979536e430a:generic-api-key",
+      "severity": "Critical",
+      "confidence": "Unknown",
+      "raw_source_code_extract": "live_5c03155f2266f3e00c20179c5b65502ab92",
+      "scanner": {
+        "id": "gitleaks",
+        "name": "Gitleaks"
+      },
+      "location": {
+        "file": "secrets.go",
+        "commit": {
+          "sha": "0000000"
+        },
+        "start_line": 66,
+        "end_line": 66
+      },
+      "identifiers": [
+        {
+          "type": "gitleaks_rule_id",
+          "name": "Gitleaks rule ID generic-api-key",
+          "value": "generic-api-key"
+        }
+      ]
+    },
+    {
+      "id": "fc1e641317be592401422d3a288c74d948676cffca47491561e62d13187a7a20",
+      "category": "secret_detection",
+      "name": "Generic API Key",
+      "message": "Generic API Key detected; please remove and revoke it if this is a leak.",
+      "description": "Generic API Key",
+      "cve": "secrets.go:34ca1bc43f78936bb999aefe8c64e1fc6def39ec4221cc0fed9beb55baffad6c:generic-api-key",
+      "severity": "Critical",
+      "confidence": "Unknown",
+      "raw_source_code_extract": "live_pub_0e1fe852b24b86f5cbd57192df2cabb",
+      "scanner": {
+        "id": "gitleaks",
+        "name": "Gitleaks"
+      },
+      "location": {
+        "file": "secrets.go",
+        "commit": {
+          "sha": "0000000"
+        },
+        "start_line": 68,
+        "end_line": 68
+      },
+      "identifiers": [
+        {
+          "type": "gitleaks_rule_id",
+          "name": "Gitleaks rule ID generic-api-key",
+          "value": "generic-api-key"
+        }
+      ]
+    },
+    {
+      "id": "bc315b03465e0140cc44ab687eff5c0c6848f0e648ac633f476757324f3d8136",
+      "category": "secret_detection",
+      "name": "PGP private key",
+      "message": "PGP private key detected; please remove and revoke it if this is a leak.",
+      "description": "PGP private key",
+      "cve": "keys/pgp_rsa_key:8a1ddaa7dab83b9a5ffe092bc3aad1df30c2e0be6246aee0a0da616d628d1da7:PGP-PK",
+      "severity": "Critical",
+      "confidence": "Unknown",
+      "raw_source_code_extract": "-----BEGIN PGP PRIVATE KEY BLOCK-----",
+      "scanner": {
+        "id": "gitleaks",
+        "name": "Gitleaks"
+      },
+      "location": {
+        "file": "keys/pgp_rsa_key",
+        "commit": {
+          "sha": "0000000"
+        },
+        "start_line": 1,
+        "end_line": 1
+      },
+      "identifiers": [
+        {
+          "type": "gitleaks_rule_id",
+          "name": "Gitleaks rule ID PGP-PK",
+          "value": "PGP-PK"
+        }
+      ]
+    }
+  ],
+  "scan": {
+    "scanner": {
+      "id": "gitleaks",
+      "name": "Gitleaks",
+      "url": "https://github.com/zricethezav/gitleaks",
+      "vendor": {
+        "name": "GitLab"
+      },
+      "version": "8.6.1"
+    },
+    "type": "secret_detection",
+    "start_time": "2022-11-08T15:00:06",
+    "end_time": "2022-11-08T15:00:08",
+    "status": "success"
+  }
+}

--- a/tests/resources/test_secrets/test_secret_suppression/ss2ju-config.yml
+++ b/tests/resources/test_secrets/test_secret_suppression/ss2ju-config.yml
@@ -1,0 +1,4 @@
+sast:
+  suppressions:
+    - type: "gitleaks_rule_id"
+      value: "PGP-PK"

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -1,0 +1,52 @@
+import json
+import unittest
+
+from secscanner2junit import SecretsParser
+from secscanner2junit.config import get_config
+
+
+class TestSecrets(unittest.TestCase):
+
+    def test_secret_name(self):
+        # given:
+        # https://gitlab.com/gitlab-examples/security/security-reports/-/blob/master/samples/secret-detection.json
+        input_report_path = "resources/test_secrets/test_secret_suppression/gl-secret-detection.json"
+        input_config_path = "resources/test_secrets/test_secret_name/no-config.yml"
+
+        report = get_report(input_report_path)
+        config = get_config(input_config_path)
+        parser = SecretsParser(report, input_report_path, config)
+
+        # when:
+        testsuite = parser.parse()
+
+        # then:
+        testsuite = testsuite.pop()
+        self.assertEqual(len(testsuite.test_cases), 5)
+
+        testcase = testsuite.test_cases.pop()
+        # The test case name must be unique or it will be deduplicated even
+        # when it describes a different occurrence. (line number etc.)
+        self.assertEqual(testcase.name, 'PGP private key (ID: bc315b03465e0140cc44ab687eff5c0c6848f0e648ac633f476757324f3d8136) (Severity: Critical)')
+
+
+    def test_secret_suppression(self):
+        # given:
+        # https://gitlab.com/gitlab-examples/security/security-reports/-/blob/master/samples/secret-detection.json
+        input_report_path = "resources/test_secrets/test_secret_suppression/gl-secret-detection.json"
+        input_config_path = "resources/test_secrets/test_secret_suppression/ss2ju-config.yml"
+
+        report = get_report(input_report_path)
+        config = get_config(input_config_path)
+        parser = SecretsParser(report, input_report_path, config)
+
+        # when:
+        testsuite = parser.parse()
+
+        # then:
+        self.assertEqual(len(testsuite.pop().test_cases), 4)
+
+
+def get_report(path):
+    with open(path) as input_file:
+        return json.load(input_file)


### PR DESCRIPTION
This issue was [fixed for the sast parser](https://github.com/angrymeir/SecScanner2JUnit/issues/9) but not for the secrets.
- Add id to testcase name for secrets
- Use vulnerability class to parse findings
- Add test for secrets